### PR TITLE
web-components.json (Web Components auto-completion in HTML files in VS Code)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .build/
 .package/
-.vscode/
 node_modules/
 *.sublime-workspace
 *.sublime-project

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "html.experimental.customData": ["./.vscode/web-components.json"],
+    "json.schemas": [
+        {
+            "fileMatch": ["./.vscode/web-components.json"],
+            "url": "https://raw.githubusercontent.com/Microsoft/vscode-html-languageservice/master/docs/customData.schema.json"
+        }
+    ]
+}

--- a/.vscode/web-components.json
+++ b/.vscode/web-components.json
@@ -1,0 +1,1130 @@
+{
+    "version": 1,
+    "tags": [
+        {
+            "name": "rester-ace-input",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "value",
+                    "description": ""
+                },
+                {
+                    "name": "mode",
+                    "description": ""
+                },
+                {
+                    "name": "read-only",
+                    "description": ""
+                },
+                {
+                    "name": "use-wrap-mode",
+                    "description": ""
+                },
+                {
+                    "name": "max-lines",
+                    "description": ""
+                },
+                {
+                    "name": "disable-search",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-authorization-input",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "authorization",
+                    "description": ""
+                },
+                {
+                    "name": "tokens",
+                    "description": ""
+                },
+                {
+                    "name": "configurations",
+                    "description": ""
+                },
+                {
+                    "name": "providers",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-authorization-provider-basic",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "provider-id",
+                    "description": ""
+                },
+                {
+                    "name": "title",
+                    "description": ""
+                },
+                {
+                    "name": "needs-configuration",
+                    "description": ""
+                },
+                {
+                    "name": "supports-incognito",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-authorization-provider-cookie",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "provider-id",
+                    "description": ""
+                },
+                {
+                    "name": "title",
+                    "description": ""
+                },
+                {
+                    "name": "needs-configuration",
+                    "description": ""
+                },
+                {
+                    "name": "supports-incognito",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-authorization-provider-custom",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "provider-id",
+                    "description": ""
+                },
+                {
+                    "name": "title",
+                    "description": ""
+                },
+                {
+                    "name": "needs-configuration",
+                    "description": ""
+                },
+                {
+                    "name": "supports-incognito",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-authorization-provider-oauth2",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "provider-id",
+                    "description": ""
+                },
+                {
+                    "name": "title",
+                    "description": ""
+                },
+                {
+                    "name": "needs-configuration",
+                    "description": ""
+                },
+                {
+                    "name": "supports-incognito",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-autocomplete-input",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "name",
+                    "description": ""
+                },
+                {
+                    "name": "placeholder",
+                    "description": ""
+                },
+                {
+                    "name": "label",
+                    "description": ""
+                },
+                {
+                    "name": "autofocus",
+                    "description": ""
+                },
+                {
+                    "name": "no-label-float",
+                    "description": ""
+                },
+                {
+                    "name": "value",
+                    "description": ""
+                },
+                {
+                    "name": "items",
+                    "description": ""
+                },
+                {
+                    "name": "dropdown-items-visible",
+                    "description": ""
+                },
+                {
+                    "name": "sort-by-index",
+                    "description": ""
+                },
+                {
+                    "name": "invalid",
+                    "description": ""
+                },
+                {
+                    "name": "required",
+                    "description": ""
+                },
+                {
+                    "name": "disabled",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-autocomplete",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "for",
+                    "description": ""
+                },
+                {
+                    "name": "items",
+                    "description": ""
+                },
+                {
+                    "name": "dropdown-items-visible",
+                    "description": ""
+                },
+                {
+                    "name": "item-template",
+                    "description": ""
+                },
+                {
+                    "name": "selected-index",
+                    "description": ""
+                },
+                {
+                    "name": "dropdown-visible",
+                    "description": ""
+                },
+                {
+                    "name": "input-value",
+                    "description": ""
+                },
+                {
+                    "name": "sort-by-index",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-body-input",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "value",
+                    "description": ""
+                },
+                {
+                    "name": "files",
+                    "description": ""
+                },
+                {
+                    "name": "content-type",
+                    "description": ""
+                },
+                {
+                    "name": "input-options",
+                    "description": ""
+                },
+                {
+                    "name": "selected-input-option",
+                    "description": ""
+                },
+                {
+                    "name": "ace-max-lines",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-code-output",
+            "description": "",
+            "attributes": []
+        },
+        {
+            "name": "rester-dom-purify-frame",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "html",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-edit-environment-dialog",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "data",
+                    "description": ""
+                },
+                {
+                    "name": "value-items",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-file-input",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "name",
+                    "description": ""
+                },
+                {
+                    "name": "label",
+                    "description": ""
+                },
+                {
+                    "name": "required",
+                    "description": ""
+                },
+                {
+                    "name": "file",
+                    "description": ""
+                },
+                {
+                    "name": "value",
+                    "description": ""
+                },
+                {
+                    "name": "override-value",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-form-data-input",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "value",
+                    "description": ""
+                },
+                {
+                    "name": "files",
+                    "description": ""
+                },
+                {
+                    "name": "no-encode",
+                    "description": ""
+                },
+                {
+                    "name": "text-only",
+                    "description": ""
+                },
+                {
+                    "name": "form-data-entries",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-header-input",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "value",
+                    "description": ""
+                },
+                {
+                    "name": "headers",
+                    "description": ""
+                },
+                {
+                    "name": "request-headers",
+                    "description": ""
+                },
+                {
+                    "name": "request-header-values",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-highlight-body",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "body",
+                    "description": ""
+                },
+                {
+                    "name": "body-formatted",
+                    "description": ""
+                },
+                {
+                    "name": "rendered-body",
+                    "description": ""
+                },
+                {
+                    "name": "content-type",
+                    "description": ""
+                },
+                {
+                    "name": "language",
+                    "description": ""
+                },
+                {
+                    "name": "ace-mode",
+                    "description": ""
+                },
+                {
+                    "name": "ace-max-lines",
+                    "description": ""
+                },
+                {
+                    "name": "pretty-print-mode",
+                    "description": ""
+                },
+                {
+                    "name": "pretty-print-status",
+                    "description": ""
+                },
+                {
+                    "name": "is-pretty-print-supported",
+                    "description": ""
+                },
+                {
+                    "name": "is-pretty-print-in-progress",
+                    "description": ""
+                },
+                {
+                    "name": "is-pretty-print-error",
+                    "description": ""
+                },
+                {
+                    "name": "is-preview-supported",
+                    "description": ""
+                },
+                {
+                    "name": "render-preview",
+                    "description": ""
+                },
+                {
+                    "name": "show-wrap-mode-warning",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-highlight-headers",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "headers",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-request-title-input",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "request-collection",
+                    "description": ""
+                },
+                {
+                    "name": "request-title",
+                    "description": ""
+                },
+                {
+                    "name": "name",
+                    "description": ""
+                },
+                {
+                    "name": "required",
+                    "description": ""
+                },
+                {
+                    "name": "value",
+                    "description": ""
+                },
+                {
+                    "name": "request-collections",
+                    "description": ""
+                },
+                {
+                    "name": "has-collection",
+                    "description": ""
+                },
+                {
+                    "name": "has-trailing-slash",
+                    "description": ""
+                },
+                {
+                    "name": "has-title",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-subheader",
+            "description": "",
+            "attributes": []
+        },
+        {
+            "name": "rester-url-input",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "label",
+                    "description": ""
+                },
+                {
+                    "name": "name",
+                    "description": ""
+                },
+                {
+                    "name": "value",
+                    "description": ""
+                },
+                {
+                    "name": "required",
+                    "description": ""
+                },
+                {
+                    "name": "origin-and-path",
+                    "description": ""
+                },
+                {
+                    "name": "query",
+                    "description": ""
+                },
+                {
+                    "name": "expanded",
+                    "description": ""
+                },
+                {
+                    "name": "invalid",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-variables-input",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "value",
+                    "description": ""
+                },
+                {
+                    "name": "source-obj",
+                    "description": ""
+                },
+                {
+                    "name": "variables",
+                    "description": ""
+                },
+                {
+                    "name": "provided-variables",
+                    "description": ""
+                },
+                {
+                    "name": "last-used-variables",
+                    "description": ""
+                },
+                {
+                    "name": "variable-history",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-data-navigation",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "items",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-drawer-footer-links",
+            "description": "",
+            "attributes": []
+        },
+        {
+            "name": "rester-navigation-list-item",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "item",
+                    "description": ""
+                },
+                {
+                    "name": "indent-level",
+                    "description": ""
+                },
+                {
+                    "name": "route",
+                    "description": ""
+                },
+                {
+                    "name": "active",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-navigation-list",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "route",
+                    "description": ""
+                },
+                {
+                    "name": "items",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-notifications",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "notifications",
+                    "description": ""
+                },
+                {
+                    "name": "is-empty",
+                    "description": ""
+                },
+                {
+                    "name": "icon",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-pages",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "page",
+                    "description": ""
+                },
+                {
+                    "name": "page-title",
+                    "description": ""
+                },
+                {
+                    "name": "route",
+                    "description": ""
+                },
+                {
+                    "name": "show-drawer-toggle",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-page-about",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "version",
+                    "description": ""
+                },
+                {
+                    "name": "libraries",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-page-environments",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "environments",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-page-history",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "history-entries",
+                    "description": ""
+                },
+                {
+                    "name": "more-entries-available",
+                    "description": ""
+                },
+                {
+                    "name": "loading",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-page-organize",
+            "description": "",
+            "attributes": []
+        },
+        {
+            "name": "rester-page-request",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "route",
+                    "description": ""
+                },
+                {
+                    "name": "route-active",
+                    "description": ""
+                },
+                {
+                    "name": "route-data",
+                    "description": ""
+                },
+                {
+                    "name": "history-route",
+                    "description": ""
+                },
+                {
+                    "name": "history-route-active",
+                    "description": ""
+                },
+                {
+                    "name": "history-route-data",
+                    "description": ""
+                },
+                {
+                    "name": "page-full-width",
+                    "description": ""
+                },
+                {
+                    "name": "is-wide-enough-to-show-variables-on-side",
+                    "description": ""
+                },
+                {
+                    "name": "request",
+                    "description": ""
+                },
+                {
+                    "name": "request-variable-values",
+                    "description": ""
+                },
+                {
+                    "name": "request-methods",
+                    "description": ""
+                },
+                {
+                    "name": "request-is-sending",
+                    "description": ""
+                },
+                {
+                    "name": "request-is-sending-and-abortable",
+                    "description": ""
+                },
+                {
+                    "name": "request-show-variables-on-side",
+                    "description": ""
+                },
+                {
+                    "name": "request-selected-tab",
+                    "description": ""
+                },
+                {
+                    "name": "request-content-type",
+                    "description": ""
+                },
+                {
+                    "name": "request-authorization",
+                    "description": ""
+                },
+                {
+                    "name": "response",
+                    "description": ""
+                },
+                {
+                    "name": "response-badge-type",
+                    "description": ""
+                },
+                {
+                    "name": "response-content-type",
+                    "description": ""
+                },
+                {
+                    "name": "history-entry",
+                    "description": ""
+                },
+                {
+                    "name": "history-entry-size",
+                    "description": ""
+                },
+                {
+                    "name": "history-entry-duration",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-page-settings",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "request-mode",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-app",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "route",
+                    "description": ""
+                },
+                {
+                    "name": "route-data",
+                    "description": ""
+                },
+                {
+                    "name": "route-tail",
+                    "description": ""
+                },
+                {
+                    "name": "page",
+                    "description": ""
+                },
+                {
+                    "name": "page-title",
+                    "description": ""
+                },
+                {
+                    "name": "responsive-width",
+                    "description": ""
+                },
+                {
+                    "name": "responsive-width-min",
+                    "description": ""
+                },
+                {
+                    "name": "responsive-width-max",
+                    "description": ""
+                },
+                {
+                    "name": "show-drawer-lock-media-query",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-authorization-provider-basic-generate-token-dialog",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "data",
+                    "description": ""
+                },
+                {
+                    "name": "form",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-authorization-provider-cookie-configuration-dialog",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "data",
+                    "description": ""
+                },
+                {
+                    "name": "form",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-authorization-provider-custom-generate-token-dialog",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "data",
+                    "description": ""
+                },
+                {
+                    "name": "form",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-authorization-provider-oauth2-configuration-dialog",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "data",
+                    "description": ""
+                },
+                {
+                    "name": "form",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-authorization-provider-oauth2-generate-token-resource-owner-dialog",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "data",
+                    "description": ""
+                },
+                {
+                    "name": "form",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-badge",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "type",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-cleanup-history-dialog",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "large-entries",
+                    "description": ""
+                },
+                {
+                    "name": "delete-large-entries",
+                    "description": ""
+                },
+                {
+                    "name": "entries",
+                    "description": ""
+                },
+                {
+                    "name": "entry-count-to-delete",
+                    "description": ""
+                },
+                {
+                    "name": "can-delete-entries",
+                    "description": ""
+                },
+                {
+                    "name": "is-deleting-entries",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-curl-command-dialog",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "data",
+                    "description": ""
+                },
+                {
+                    "name": "curl-command",
+                    "description": ""
+                },
+                {
+                    "name": "copy-to-clipboard-not-supported",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-environment-select-dialog",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "environments",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-error",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "title",
+                    "description": ""
+                },
+                {
+                    "name": "error",
+                    "description": ""
+                },
+                {
+                    "name": "error-message",
+                    "description": ""
+                },
+                {
+                    "name": "error-message-lines",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-export-dialog",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "format",
+                    "description": ""
+                },
+                {
+                    "name": "include-history",
+                    "description": ""
+                },
+                {
+                    "name": "is-preparing-export",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-highlight-language-select-dialog",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "data",
+                    "description": ""
+                },
+                {
+                    "name": "supported-languages",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-hotkeys-cheat-sheet",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "hotkeys",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-import-dialog",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "file",
+                    "description": ""
+                },
+                {
+                    "name": "collection-prefix",
+                    "description": ""
+                },
+                {
+                    "name": "is-importing",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-lint-messages",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "messages",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-quick-open-dialog",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "search-text",
+                    "description": ""
+                },
+                {
+                    "name": "items",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-redirected-help-dialog",
+            "description": "",
+            "attributes": []
+        },
+        {
+            "name": "rester-timing-duration-dialog",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "data",
+                    "description": ""
+                },
+                {
+                    "name": "data-available",
+                    "description": ""
+                },
+                {
+                    "name": "timeline",
+                    "description": ""
+                }
+            ]
+        },
+        {
+            "name": "rester-timing-size-dialog",
+            "description": "",
+            "attributes": [
+                {
+                    "name": "data",
+                    "description": ""
+                }
+            ]
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -69,8 +69,9 @@
     "web-animations-js": "2.3.2"
   },
   "devDependencies": {
-    "@babel/core": "^7.4.5",
-    "@babel/preset-env": "^7.4.5",
+    "@babel/core": "7.4.5",
+    "@babel/parser": "7.4.5",
+    "@babel/preset-env": "7.4.5",
     "addons-linter": "1.10.0",
     "archiver": "3.0.0",
     "babel-eslint": "10.0.2",

--- a/tools/dev-utils/gen-web-components-json.js
+++ b/tools/dev-utils/gen-web-components-json.js
@@ -1,0 +1,118 @@
+/* eslint-disable no-console */
+
+// Generate custom data about web components in this project for the VS Code
+// HTML Language Service.
+// https://github.com/Microsoft/vscode-html-languageservice/blob/master/docs/customData.md
+
+'use strict';
+
+const babelParser = require('@babel/parser');
+const fs = require('fs');
+const { promisify } = require('util');
+const readdir = promisify(fs.readdir);
+const readFile = promisify(fs.readFile);
+const stat = promisify(fs.stat);
+const writeFile = promisify(fs.writeFile);
+
+function camelToKebabCase(str) {
+    return str.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+}
+
+async function readdirRecursive(dir) {
+    const files = (await readdir(dir)).map(file => dir + '/' + file);
+    const recursiveFiles = [];
+    for (const file of files) {
+        if ((await stat(file)).isDirectory()) {
+            recursiveFiles.push(...(await readdirRecursive(file)));
+        } else {
+            recursiveFiles.push(file);
+        }
+    }
+
+    return recursiveFiles;
+}
+
+function isPolymerElement(superClass) {
+    return (
+        (superClass.type === 'Identifier' &&
+            superClass.name === 'PolymerElement') ||
+        (superClass.type === 'CallExpression' &&
+            superClass.callee.name.toLowerCase().includes('mixin') &&
+            superClass.arguments.length === 1 &&
+            isPolymerElement(superClass.arguments[0]))
+    );
+}
+
+function isStaticGetter(statement, name) {
+    return (
+        statement.type === 'ClassMethod' &&
+        statement.kind === 'get' &&
+        statement.key.name === name
+    );
+}
+
+async function getWebComponentsInFile(file) {
+    const code = await readFile(file, 'utf8');
+    const ast = babelParser.parse(code, {
+        sourceType: 'module',
+        sourceFilename: file
+    });
+    const body = ast.program.body;
+
+    const classes = body.filter(
+        statement =>
+            statement.type === 'ClassDeclaration' &&
+            statement.superClass &&
+            isPolymerElement(statement.superClass)
+    );
+    const webComponents = classes.map(statement => {
+        const body = statement.body.body;
+        const is = body.find(statement => isStaticGetter(statement, 'is'));
+        const name = is.body.body.find(
+            statement => statement.type === 'ReturnStatement'
+        ).argument.value;
+        const properties = body.find(statement =>
+            isStaticGetter(statement, 'properties')
+        );
+        const attributes = properties
+            ? properties.body.body
+                  .find(statement => statement.type === 'ReturnStatement')
+                  .argument.properties.map(property => {
+                      const name = camelToKebabCase(property.key.name);
+                      return {
+                          name,
+                          description: ''
+                      };
+                  })
+            : [];
+
+        return {
+            name,
+            description: '',
+            attributes
+        };
+    });
+
+    return webComponents;
+}
+
+async function main() {
+    const files = await readdirRecursive('src/site');
+    const jsFiles = files.filter(file => file.endsWith('.js'));
+    const webComponents = {
+        version: 1,
+        tags: []
+    };
+    for (const file of jsFiles) {
+        console.log('Reading Web Components in file', file);
+        webComponents.tags.push(...(await getWebComponentsInFile(file)));
+    }
+
+    await writeFile(
+        '.vscode/web-components.json',
+        JSON.stringify(webComponents, null, 4),
+        'utf8'
+    );
+}
+
+main().catch(console.error);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,7 +9,7 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
-"@babel/core@^7.1.0", "@babel/core@^7.4.5":
+"@babel/core@7.4.5", "@babel/core@^7.1.0":
   version "7.4.5"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.4.5.tgz#081f97e8ffca65a9b4b0fdc7e274e703f000c06a"
   integrity sha512-OvjIh6aqXtlsA8ujtGKfC7LYWksYSX8yQcM8Ay3LuvVeQ63lcOKgoZWVqcpFwkd29aYU9rVx7jxhfhiEDV9MZA==
@@ -213,7 +213,7 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.4.3", "@babel/parser@^7.4.4", "@babel/parser@^7.4.5":
+"@babel/parser@7.4.5", "@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.4.3", "@babel/parser@^7.4.4", "@babel/parser@^7.4.5":
   version "7.4.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.4.5.tgz#04af8d5d5a2b044a2a1bffacc1e5e6673544e872"
   integrity sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==
@@ -531,7 +531,7 @@
     "@babel/helper-regex" "^7.4.4"
     regexpu-core "^4.5.4"
 
-"@babel/preset-env@^7.4.5":
+"@babel/preset-env@7.4.5":
   version "7.4.5"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.4.5.tgz#2fad7f62983d5af563b5f3139242755884998a58"
   integrity sha512-f2yNVXM+FsR5V8UwcFeIHzHWgnhXg3NpRmy0ADvALpnhB0SLbCvrCRr4BLOUYbQNLS+Z0Yer46x9dJXpXewI7w==


### PR DESCRIPTION
VS Code added experimental support for Web Component auto-completion in HTML files.

This PR adds a `web-components.json` file including all Web Components in this repository and a simple generation script for it.

Unfortunately auto-completion doesn't seem to work in tagged template literals with extensions like [lit-html](https://marketplace.visualstudio.com/items?itemName=bierner.lit-html), yet. Until that starts working there is probably no point in merging this.