### PR TITLE
Fixed regexp variable matching rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+-   Fixed variable matching regular expression rule.
+
 ## [4.0.0] - 2020-03-14
 
 ### Changed

--- a/src/site/elements/controls/rester-edit-environment-dialog.js
+++ b/src/site/elements/controls/rester-edit-environment-dialog.js
@@ -11,6 +11,7 @@ import '../../../../node_modules/@polymer/paper-input/paper-input.js';
 import '../../../../node_modules/@polymer/paper-input/paper-textarea.js';
 import '../../../../node_modules/web-animations-js/web-animations-next-lite.min.js';
 import '../styles/rester-icons.js';
+import { RE_PATTERN_VAR } from '../data/scripts/variables.js';
 import RESTerDialogControllerMixin from '../utils/rester-dialog-controller-mixin.js';
 
 /**
@@ -25,7 +26,7 @@ class RESTerEditEnvironmentDialog extends RESTerDialogControllerMixin(
         return html`
             <style>
                 paper-dialog {
-                    max-width: 600px;
+                    width: 1000px;
                 }
 
                 .value-line {
@@ -77,7 +78,10 @@ class RESTerEditEnvironmentDialog extends RESTerDialogControllerMixin(
                                     <paper-input
                                         label="Key"
                                         value="{{item.key}}"
+                                        pattern="^[[rePatternVar]]$"
                                         on-value-changed="_ensureEmptyValueItem"
+                                        error-message="Can only contain alphanumeric or ._-$ characters"
+                                        auto-validate
                                     ></paper-input>
                                     <paper-textarea
                                         label="Value"
@@ -121,7 +125,10 @@ class RESTerEditEnvironmentDialog extends RESTerDialogControllerMixin(
             valueItems: {
                 type: Array,
                 readOnly: true
-            }
+            },
+            rePatternVar: {
+                value: RE_PATTERN_VAR
+            },
         };
     }
 

--- a/src/site/elements/controls/rester-edit-environment-dialog.js
+++ b/src/site/elements/controls/rester-edit-environment-dialog.js
@@ -27,6 +27,7 @@ class RESTerEditEnvironmentDialog extends RESTerDialogControllerMixin(
             <style>
                 paper-dialog {
                     width: 1000px;
+                    max-width: 90vw;
                 }
 
                 .value-line {

--- a/src/site/elements/controls/rester-variables-input.js
+++ b/src/site/elements/controls/rester-variables-input.js
@@ -30,8 +30,9 @@ class RESTerVariablesInput extends RESTerVariablesMixin(PolymerElement) {
 
             <p class="hint">
                 You can use placeholders everywhere in the request with curly
-                brackets, e.g. <code>{id}</code> or <code>{title}</code>. Below
-                you see input fields for each of these variables.
+                brackets, e.g. <code>{id}</code> or <code>{title}</code>. Placeholders can
+                contain alphanumeric characters as well as <code>$._-</code>. Below you see input fields
+                for each of these variables.
             </p>
 
             <template

--- a/src/site/elements/data/scripts/variables.js
+++ b/src/site/elements/data/scripts/variables.js
@@ -5,7 +5,8 @@ import providerEnv from './variables-provider-env.js';
 export const e = new CustomEventTarget();
 export const providedValues = {};
 
-const RE_VARS = /\{([\w$-]+(\.[\w$-]+)*)\}/g;
+export const RE_PATTERN_VAR = '[\\w$-]+(\\.[\\w$-]+)*';
+const RE_VARS = new RegExp('\\{('+ RE_PATTERN_VAR +')\\}', 'g');
 const providers = [providerEnv];
 
 collectProvidedValues();

--- a/src/site/elements/data/scripts/variables.js
+++ b/src/site/elements/data/scripts/variables.js
@@ -5,7 +5,7 @@ import providerEnv from './variables-provider-env.js';
 export const e = new CustomEventTarget();
 export const providedValues = {};
 
-const RE_VARS = /\{(\S+?)\}/gi;
+const RE_VARS = /\{([\w$-]+(\.[\w$-]+)*)\}/g;
 const providers = [providerEnv];
 
 collectProvidedValues();


### PR DESCRIPTION
#116 #44


Additional notes for this regexp rule.
-    {dot..dot} characters considered is not variable
-    {variable.} can't contains dot character at the end

