### PR TITLE
Fix on extracting library name

### DIFF
--- a/tools/plugins/generate-library-links.js
+++ b/tools/plugins/generate-library-links.js
@@ -10,7 +10,7 @@ function generateUsedLibraries(webPackFiles) {
         .sort()
         .filter((path, index, self) => self.indexOf(path) === index)
         .filter(path => path.startsWith('node_modules/'))
-        .map(path => path.substr('node_modules/'.length))
+        .map(path => path.substr(path.lastIndexOf('node_modules/') + 'node_modules/'.length))
         .reduce((libs, path) => {
             const lib = path.startsWith('@')
                 ? path.substr(0, path.indexOf('/', path.indexOf('/') + 1))


### PR DESCRIPTION
While I prefered use pnpm package manager. pnpm stored everything modules under `node_modules/.pnpm` folder thus webpack getting long library paths
```
[1]       'node_modules/.pnpm/registry.npmjs.org/@polymer/app-layout/3.1.0/node_modules/@polymer/app-layout/app-drawer-layout/app-drawer-layout.js',
[1]       'node_modules/.pnpm/registry.npmjs.org/@polymer/app-layout/3.1.0/node_modules/@polymer/app-layout/app-drawer/app-drawer.js',
[1]       'node_modules/.pnpm/registry.npmjs.org/@polymer/app-layout/3.1.0/node_modules/@polymer/app-layout/app-header-layout/app-header-layout.js',
[1]       'node_modules/.pnpm/registry.npmjs.org/@polymer/app-layout/3.1.0/node_modules/@polymer/app-layout/app-header/app-header.js',
[1]       'node_modules/.pnpm/registry.npmjs.org/@polymer/app-layout/3.1.0/node_modules/@polymer/app-layout/app-layout-behavior/app-layout-behavior.js',
[1]       'node_modules/.pnpm/registry.npmjs.org/@polymer/app-layout/3.1.0/node_modules/@polymer/app-layout/app-scroll-effects/app-scroll-effects-behavior.js',
[1]       'node_modules/.pnpm/registry.npmjs.org/@polymer/app-layout/3.1.0/node_modules/@polymer/app-layout/app-toolbar/app-toolbar.js',
[1]       'node_modules/.pnpm/registry.npmjs.org/@polymer/app-layout/3.1.0/node_modules/@polymer/app-layout/helpers/helpers.js',
[1]       'node_modules/.pnpm/registry.npmjs.org/@polymer/app-route/3.0.2/node_modules/@polymer/app-route/app-location.js',
[1]       'node_modules/.pnpm/registry.npmjs.org/@polymer/app-route/3.0.2/node_modules/@polymer/app-route/app-route-converter-behavior.js',
[1]       'node_modules/.pnpm/registry.npmjs.org/@polymer/app-route/3.0.2/node_modules/@polymer/app-route/app-route.js',
[1]       'node_modules/.pnpm/registry.npmjs.o
```

 `pnpm run start` resulting error like so
```
[1] Error: Cannot find module '../../node_modules/.pnpm/package.json'
[1] Require stack:
[1] - H:\cup\www\osp\rester\tools\plugins\generate-library-links.js
[1] - H:\cup\www\osp\rester\webpack.config.js
[1] - H:\cup\www\osp\rester\node_modules.pnpm\registry.npmjs.org\webpack-cli\3.3.11_webpack@4.42.0\node_modules\webpack-cli\bin\utils\convert-argv.js
...
```