### PR TITLE
Fix e2e tests

### DIFF
--- a/test-e2e/__snapshots__/index.test.js.snap
+++ b/test-e2e/__snapshots__/index.test.js.snap
@@ -34,7 +34,7 @@ Accept-Language: en
 Accept-Encoding: gzip, deflate
 Content-Type: text/plain;charset=UTF-8
 Content-Length: 0
-Origin: null
+Origin: moz-extension://595108c3-fc1a-46bc-a6f6-918a6b1898aa
 Connection: keep-alive
 Pragma: no-cache
 Cache-Control: no-cache


### PR DESCRIPTION
Apparently we get a non-null origin header again.