### PR TITLE
Don't remove cookie on auth selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+-   Don't remove manually entered Cookie header when selecting an Authorization in the Authorization tab ([#395](https://github.com/frigus02/RESTer/issues/395)).
+
 ## [4.5.0] - 2021-06-02
 
 ### Added

--- a/docs/library-links.md
+++ b/docs/library-links.md
@@ -378,9 +378,9 @@ https://unpkg.com/ace-builds@1.4.12/src-min-noconflict/worker-html.js
 https://unpkg.com/ace-builds@1.4.12/src-min-noconflict/worker-json.js
 https://unpkg.com/ace-builds@1.4.12/src-min-noconflict/worker-xml.js
 
-dompurify 2.2.8
-https://unpkg.com/dompurify@2.2.8/dist/purify.es.js
-https://unpkg.com/dompurify@2.2.8/package.json
+dompurify 2.2.9
+https://unpkg.com/dompurify@2.2.9/dist/purify.es.js
+https://unpkg.com/dompurify@2.2.9/package.json
 
 frigus02-vkbeautify 1.0.1
 https://unpkg.com/frigus02-vkbeautify@1.0.1/package.json

--- a/src/background/data/requests.js
+++ b/src/background/data/requests.js
@@ -13,7 +13,10 @@ import db from './utils/db.js';
  * @property {String} method - The HTTP method name (GET, POST, ...).
  * @property {String} url - The url.
  * @property {Array} headers - The request headers as an array oj objects.
- * Each object has the properties `name` and `value`.
+ * Each object has the properties `name`, `value` and optionally `flag`. The
+ * `flag` stores internal RESTer metadata. Currently the only metadata is
+ * "authorization", indicating that this header has been added through the
+ * Authorization UI.
  * @property {String} body - The request body as string.
  * @property {Object} variables - Configuration of replacement variables,
  * which are applied when sending the request.

--- a/src/site/elements/pages/rester-page-request.js
+++ b/src/site/elements/pages/rester-page-request.js
@@ -807,33 +807,42 @@ class RESTerPageRequest extends RESTerLintMixin(
 
     _onRequestAuthorizationChanged(e) {
         const auth = e.detail.value;
+        const flag = 'authorization';
         if (!auth) {
-            this._setRequestHeader('Authorization', null);
-            this._setRequestHeader('Cookie', null);
+            this._setRequestHeader('Authorization', null, flag);
+            this._setRequestHeader('Cookie', null, flag);
         } else if (auth.scheme === 'Cookie') {
-            this._setRequestHeader('Authorization', null);
-            this._setRequestHeader('Cookie', auth.token);
+            this._setRequestHeader('Authorization', null, flag);
+            this._setRequestHeader('Cookie', auth.token, flag);
         } else {
             this._setRequestHeader(
                 'Authorization',
-                `${auth.scheme} ${auth.token}`
+                `${auth.scheme} ${auth.token}`,
+                flag
             );
-            this._setRequestHeader('Cookie', null);
+            this._setRequestHeader('Cookie', null, flag);
         }
     }
 
-    _setRequestHeader(headerName, value) {
-        const index = this.request.headers.findIndex(
-            (h) => h.name.toLowerCase() === headerName.toLowerCase()
-        );
-        if (index > -1) {
-            this.request.headers.splice(index, 1);
+    _setRequestHeader(headerName, value, flag) {
+        const valueSet = value !== null && value !== undefined;
+        const flagSet = flag !== null && flag !== undefined;
+
+        for (let i = this.request.headers.length - 1; i >= 0; i--) {
+            const header = this.request.headers[i];
+            if (
+                header.name.toLowerCase() === headerName.toLowerCase() &&
+                (valueSet || !flagSet || header.flag === flag)
+            ) {
+                this.request.headers.splice(i, 1);
+            }
         }
 
-        if (value || value === '') {
+        if (valueSet) {
             const newHeader = {
                 name: headerName,
                 value: value,
+                flag,
             };
 
             this.request.headers.push(newHeader);


### PR DESCRIPTION
Don't remove a manually entered Cookie header when selecting an
authorization in the Authorization tab. This works by flagging headers
added through the Authorization tab. Only flagged headers are removed
when selecting another authorization.

Exception: if the selected authorization adds an "Authorization" header,
it will override any existing "Authorization" header. And if the
selected authorization adds a "Cookie" header, it will override any
existing "Cookie" header.

Fixes #395 