### PR TITLE
Fix ace css and workers

### DIFF
--- a/src/site/elements/controls/rester-ace-input.js
+++ b/src/site/elements/controls/rester-ace-input.js
@@ -84,9 +84,10 @@ class RESTerAceInput extends RESTerThemeMixin(PolymerElement) {
     ready() {
         super.ready();
         ace.config.set('useStrictCSP', true);
+        ace.config.set('loadWorkerFromBlob', false);
         ace.config.set(
             'basePath',
-            this.resolveUrl('node_modules/ace-builds/src-min-noconflict/')
+            '/site/node_modules/ace-builds/src-min-noconflict/'
         );
     }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -64,6 +64,10 @@ module.exports = [
                         context: '../../',
                     },
                     {
+                        from: 'node_modules/ace-builds/css/{main,chrome,twilight}-*.png',
+                        context: '../../',
+                    },
+                    {
                         from: 'node_modules/ace-builds/src-min-noconflict/{ext-searchbox,mode-{html,json,text,xml},theme-{chrome,twilight},worker-{html,json,xml}}.js',
                         context: '../../',
                     },


### PR DESCRIPTION
- CSS needed images
- Worker didn't load because it tried to load the script from an
  absolute URL (chrome-extension:// or moz-extension://), which isn't
  allowed by CSP. Not loading them by blob url allows for a relative
  URL, which works fine.