### PR TITLE
Optional webRequest/webRequestBlocking permissions

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -14,12 +14,12 @@
         "downloads",
         "storage",
         "unlimitedStorage",
-        "webRequest",
-        "webRequestBlocking",
         "<all_urls>"
     ],
     "optional_permissions": [
-        "cookies"
+        "cookies",
+        "webRequest",
+        "webRequestBlocking"
     ],
     "background": {
         "scripts": [

--- a/src/site/elements/utils/rester-timing-duration-dialog.js
+++ b/src/site/elements/utils/rester-timing-duration-dialog.js
@@ -166,7 +166,7 @@ class RESTerTimingDurationDialog extends RESTerDialogControllerMixin(
             connect,
             sendRequest,
             downloadResponse,
-        ];
+        ].filter((item) => item.startAt >= 0 && item.duration >= 0);
     }
 
     _calcPercentage(full, fraction) {


### PR DESCRIPTION
Make webRequest and webRequestBlocking optional.

Fixes #524

This makes RESTer silently request webRequest permissions on the first request (it seems necessary to request permissions only on user interaction). If it fails, RESTer logs a warning to the console but proceeds.