### PR TITLE
Support formatting NaN in JSON

### DIFF
--- a/src/site/elements/data/scripts/format-json.test.js
+++ b/src/site/elements/data/scripts/format-json.test.js
@@ -19,6 +19,14 @@ describe('formatJson', function () {
         );
     });
 
+    test('throw in case of too much nesting', function () {
+        const depth = 502;
+        const json = '['.repeat(depth) + ']'.repeat(depth);
+        expect(() => formatJson(json)).toThrow(
+            'ParseError at 501: max depth reached'
+        );
+    });
+
     const values = {
         string: '"abc \\" \\\\ \\/ \\b \\f \\n \\r \\t \\u0000"',
         number: '0',
@@ -33,6 +41,7 @@ describe('formatJson', function () {
         true: 'true',
         false: 'false',
         null: 'null',
+        nan: 'NaN',
     };
     for (const [name, value] of Object.entries(values)) {
         test(`handles ${name}`, () => {


### PR DESCRIPTION
NaN seems to be a common extension to JSON. Probably because JavaScript supports it. RESTer doesn't do anything with JSON except making it easier to read. It seems reasonable to try to support JSON extensions as long as they don't make the code harder to maintain. This adds support for .

Closes #593 