### PR TITLE
Add Github Action to deploy to web stores

### DIFF
--- a/.github/workflows/deploy_to_stores.yml
+++ b/.github/workflows/deploy_to_stores.yml
@@ -1,0 +1,19 @@
+on: workflow_dispatch
+
+name: Submit to Web Stores
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2.1.2
+        with:
+          node-version: '14'
+      - run: yarn install --frozen-lockfile
+      - run: yarn build
+      - run: yarn package
+      - name: Browser Plugin Publish
+        uses: plasmo-corp/bpp@v1
+        with:
+          keys: ${{ secrets.SUBMIT_KEYS }}

--- a/docs/library-links.md
+++ b/docs/library-links.md
@@ -338,8 +338,8 @@ https://unpkg.com/ace-builds@1.4.14/src-min-noconflict/worker-html.js
 https://unpkg.com/ace-builds@1.4.14/src-min-noconflict/worker-json.js
 https://unpkg.com/ace-builds@1.4.14/src-min-noconflict/worker-xml.js
 
-dompurify 2.3.5
-https://unpkg.com/dompurify@2.3.5/dist/purify.es.js
+dompurify 2.3.6
+https://unpkg.com/dompurify@2.3.6/dist/purify.es.js
 
 frigus02-vkbeautify 1.0.1
 https://unpkg.com/frigus02-vkbeautify@1.0.1/vkbeautify.js


### PR DESCRIPTION
Hey @frigus02, we created a [Github action](https://github.com/marketplace/actions/browser-plugin-publisher) to make it easier to publish extensions to the various web stores.

Thought y'all might find it useful so I added a Github workflow that will build the extension, zip it up, and publish to the web stores on dispatch.

The only thing you would need to create is a `SUBMIT_KEYS` GitHub repository secret.

This secret is a JSON, with the schema defined [here](https://raw.githubusercontent.com/plasmo-corp/bpp/v1/keys.schema.json).

Here's a sample key with the correct `zip` values for RESTer (the `{version}` will automatically populate with whatever the version of the `package.json` is:

```
{
  "$schema": "https://raw.githubusercontent.com/plasmo-corp/bpp/v1/keys.schema.json",
  "chrome": {
    "zip": "./.package/chrome-{version}.zip",
    "clientId": "123",
    "clientSecret": "456",
    "refreshToken": "789",
    "extId": "abcd"
  },
  "firefox": {
    "zip": "./.package/firefox-{version}.zip",
    "apiKey": "123",
    "apiSecret": "abcd",
    "extId": "foobar"
  }
}
```

You can find instructions on how to get those keys in the schema, or if you use vscode, the schema should provide hint/intelisense when hovering over the json properties. If you need any help in setting up the keys, feel free to @ me.

Otherwise, if this doesn't seem necessary, feel free to close the PR!