### PR TITLE
Ensure permissions have been requested for OAuth2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 -   Always encode URL query params (name and value) when "Toogle URL params" is on. This fixes an issue where entering `#` in a query param would truncate the remaining URL (see [#628](https://github.com/frigus02/RESTer/issues/628)).
+-   Fixes OAuth 2 issues with invalid `Origin` header in certain cases (see [#75](https://github.com/frigus02/RESTer/issues/75#issuecomment-1072638551)).
 
 ## [4.9.0] - 2022-02-13
 

--- a/src/site/elements/data/scripts/request.js
+++ b/src/site/elements/data/scripts/request.js
@@ -40,7 +40,7 @@ function getCurrentTabId() {
 }
 
 let headerInterceptorPromise;
-function ensureHeaderInterceptor() {
+export function ensureHeaderInterceptor() {
     if (!headerInterceptorPromise) {
         headerInterceptorPromise = (async function () {
             try {


### PR DESCRIPTION
Ensure webRequest permissions have been requested for OAuth2 flow while it still counts as user interaction (during click event).

See #75 