### PR TITLE
Fix E2E: set --allow-system-access

### DIFF
--- a/tools/lib/create-web-driver.js
+++ b/tools/lib/create-web-driver.js
@@ -42,7 +42,8 @@ async function createWebDriver() {
         )
         .setPreference('xpinstall.signatures.required', false)
         .setPreference('intl.accept_languages', 'en')
-        .addExtensions(path.resolve(rootDir, 'package/firefox-selenium.xpi'));
+        .addExtensions(path.resolve(rootDir, 'package/firefox-selenium.xpi'))
+        .addArguments('--allow-system-access');
 
     if (!process.env.WITH_HEAD) {
         options.addArguments('-headless');

--- a/tools/lib/create-web-driver.js
+++ b/tools/lib/create-web-driver.js
@@ -42,16 +42,19 @@ async function createWebDriver() {
         )
         .setPreference('xpinstall.signatures.required', false)
         .setPreference('intl.accept_languages', 'en')
-        .addExtensions(path.resolve(rootDir, 'package/firefox-selenium.xpi'))
-        .addArguments('--allow-system-access');
+        .addExtensions(path.resolve(rootDir, 'package/firefox-selenium.xpi'));
 
     if (!process.env.WITH_HEAD) {
         options.addArguments('-headless');
     }
 
+    const serviceBuilder = new firefox.ServiceBuilder()
+        .addArguments('--allow-system-access');
+
     const driver = await new Builder()
         .forBrowser('firefox')
         .setFirefoxOptions(options)
+        .setFirefoxService(serviceBuilder)
         .build();
 
     return driver;


### PR DESCRIPTION
geckodriver 0.37.1 requires the --allow-system-access argument now to navigate to moz-extension:// URLs. Or maybe it requires it for navigation in general. Either way, without this change, e2e tests fail with:

    UnsupportedOperationError: Navigation to "moz-extension://595108c3-fc1a-46bc-a6f6-918a6b1898aa/site/index.html" is not allowed in this context